### PR TITLE
Add PCNTL extension

### DIFF
--- a/7.3/cli/Dockerfile
+++ b/7.3/cli/Dockerfile
@@ -26,6 +26,7 @@ RUN set -xe; \
     docker-php-ext-install \
         gd \
         opcache \
+        pcntl \
         pdo_mysql \
         pdo_pgsql \
         zip \
@@ -52,7 +53,7 @@ RUN { \
 RUN set -xe; \
     \
     curl https://getcomposer.org/installer --output composer-setup.php; \
-    \ 
+    \
     php composer-setup.php; \
     \
     rm -rf composer-setup.php; \


### PR DESCRIPTION
Steps to test:

1. `docker build -f 7.3/cli/Dockerfile . --tag docker-thunder-php:pr-2`
2. `docker run -it docker-thunder-php:pr-2 /bin/bash`
3. `php -r "echo pcntl_fork() . PHP_EOL;"`

With this branch, you should get some result for the `master` branch you should get an error.